### PR TITLE
Clean up isfshax directories after uninstallation

### DIFF
--- a/source/app/filesystem.h
+++ b/source/app/filesystem.h
@@ -16,7 +16,12 @@ bool testStorage(TITLE_LOCATION location);
 std::string convertToPosixPath(const char* volPath);
 bool fileExist(const char* path);
 bool dirExist(const char* path);
+bool isDirEmpty(const char* path);
 bool copyFile(const std::string& src, const std::string& dest);
+bool moveFile(const char* src, const char* dest);
+bool removeFile(const char* path);
+bool removeDir(const char* path);
+bool deleteDirContent(const char* path);
 
 TITLE_LOCATION deviceToLocation(const char* device);
 TITLE_LOCATION pathToLocation(const char* device);

--- a/source/app/fw_img_loader.cpp
+++ b/source/app/fw_img_loader.cpp
@@ -79,8 +79,6 @@ static const char ancast_decrypt_hook[] = {
     0xe1, 0x2f, 0xff, 0x1e, 0x01, 0x00, 0x01, 0xa0,
 };
 
-static const char path[64] = "/vol/system/hax/installer";
-
 static uint32_t generate_bl_t(uint32_t from, uint32_t to)
 {
 	int32_t bl_offs = (((int32_t)to - (int32_t)(from)) - 4) / 2;
@@ -134,7 +132,17 @@ void loadFwImg(const char* fwPath, uint32_t command, uint32_t parameter) {
     } else {
         WHBLogFreetypePrint(L"libstroopwafel not available. Applying fw.img patches...");
 
-        if (!applyPatch(0x050663B4, path, sizeof(path), L"Applying fw_path...")) return;
+        char fwDir[64];
+        std::memset(fwDir, 0, sizeof(fwDir));
+        std::string fwPathStr(fwPath);
+        size_t lastSlash = fwPathStr.find_last_of('/');
+        if (lastSlash != std::string::npos) {
+            std::strncpy(fwDir, fwPathStr.substr(0, lastSlash).c_str(), sizeof(fwDir) - 1);
+        } else {
+            std::strncpy(fwDir, "/vol/system/hax/installer", sizeof(fwDir) - 1);
+        }
+
+        if (!applyPatch(0x050663B4, fwDir, sizeof(fwDir), L"Applying fw_path...")) return;
 
         uint64_t p2 = 0x00a4F031FB43193b; // need to align patch for old mocha
         if (!applyPatch(0x050282AC, &p2, 8, L"Applying patch 2 (launch_os_hook bl)...")) return;

--- a/source/app/isfshax_menu.cpp
+++ b/source/app/isfshax_menu.cpp
@@ -55,7 +55,28 @@ void installIsfshax(bool uninstall, bool manual) {
 
     if(uninstall){
         if (confirmIsfshaxAction(L"Uninstall", true)) {
-            loadFwImg("/vol/system/hax/installer/fw.img", ISFSHAX_CMD_UNINSTALL, (uint32_t)(ISFSHAX_CMD_POST_REBOOT) << 30 | ISFSHAX_CMD_SOURCE_SLC);
+            std::string slcTmpDir = convertToPosixPath("/vol/storage_slc/sys/tmp");
+            std::string slcInstallerDir = convertToPosixPath("/vol/storage_slc/sys/hax/installer");
+            std::string slcHaxDir = convertToPosixPath("/vol/storage_slc/sys/hax");
+
+            std::string srcFwImg = convertToPosixPath("/vol/storage_slc/sys/hax/installer/fw.img");
+            std::string destFwImg = slcTmpDir + "/fw.img";
+
+            if (!dirExist(slcTmpDir.c_str())) {
+                mkdir(slcTmpDir.c_str(), 0755);
+            }
+
+            if (moveFile(srcFwImg.c_str(), destFwImg.c_str())) {
+                deleteDirContent(slcInstallerDir.c_str());
+                removeDir(slcInstallerDir.c_str());
+                if (isDirEmpty(slcHaxDir.c_str())) {
+                    removeDir(slcHaxDir.c_str());
+                }
+                loadFwImg("/vol/system/tmp/fw.img", ISFSHAX_CMD_UNINSTALL, (uint32_t)(ISFSHAX_CMD_POST_REBOOT) << 30 | ISFSHAX_CMD_SOURCE_SLC);
+            } else {
+                setErrorPrompt(L"Failed to move installer to /sys/tmp!");
+                showErrorPrompt(L"OK");
+            }
         }
         return;
     }


### PR DESCRIPTION
This change improves the isfshax uninstallation process by ensuring no traces are left in /sys/hax/. It moves the installer (fw.img) to /sys/tmp/ before launching it, deletes the original directories, and updates the firmware loader logic to support booting from the new location using both Stroopwafel and manual Mocha patches.

---
*PR created automatically by Jules for task [17232229442234897403](https://jules.google.com/task/17232229442234897403) started by @jan-hofmeier*